### PR TITLE
Fix: Local model use

### DIFF
--- a/doc_comments_ai/app.py
+++ b/doc_comments_ai/app.py
@@ -84,7 +84,6 @@ def run():
     elif args.ollama_model:
         llm_wrapper = llm.LLM(ollama=(args.ollama_base_url, args.ollama_model))
     else:
-        utils.is_openai_api_key_available()
         llm_wrapper = llm.LLM(local_model=args.local_model)
 
     generated_doc_comments = {}


### PR DESCRIPTION
This PR addresses a regression wherein a local model cannot be used if the OpenAI API key is not defined.