### PR TITLE
fix: Add a clause 'single' to constrain the LLM to not return more than one codebock

### DIFF
--- a/doc_comments_ai/llm.py
+++ b/doc_comments_ai/llm.py
@@ -57,7 +57,7 @@ class LLM:
             "Add a detailed doc comment to the following {language} method:\n{code}\n"
             "The doc comment should describe what the method does. "
             "{inline_comments} "
-            "Return the method implementaion with the doc comment as a markdown code block. "
+            "Return the method implementaion with the doc comment as a single markdown code block. "
             "Don't include any explanations {haskell_missing_signature}in your response."
         )
         self.prompt = PromptTemplate(


### PR DESCRIPTION
The LLM often produces more than one markdown blocks at least once in large source files. 
For example, in a python file's method, it would create 2 markdown blocks as:

\`\`\`markdown
\<text\>...
\`\`\`

\`\`\`python
\<code\>
\`\`\`

To avoid this, specifically instruct it to return only a single markdown block.

Closes #53